### PR TITLE
fix: update error handling to include root.message if no message found

### DIFF
--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -146,7 +146,9 @@ const FormMessage = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField();
-  const body = error ? String(error?.message) : children;
+  const body = error
+    ? String(error?.message || error?.root?.message)
+    : children;
 
   if (!body) {
     return null;


### PR DESCRIPTION
Addresses multiple errors merging into root, then showing `undefined`

**Problem:**

- Submitting a valid form after trying to submit an invalid form where there's an error on items field shows undefined on FormMessage of items.

**Solution:**

- Updated error handling in FormMessage to include checking for error.root.message before defaulting to children