### PR TITLE
fix(filterActions): ensure updatedAt is set when a filter is edited

### DIFF
--- a/src/actions/filterActions.ts
+++ b/src/actions/filterActions.ts
@@ -141,11 +141,12 @@ export const updateFilter = ownsFilterProcedure
   )
   .handler(async ({ input }) => {
     const { data, filterId, removedItems, addedItems } = input;
-    const updateData: Partial<typeof data> = {};
+    const updateData: Partial<typeof data> & { updatedAt?: Date } = {};
     if (data.name) updateData.name = data.name;
     if (data.description) updateData.description = data.description;
     if (data.imagePath) updateData.imagePath = data.imagePath;
     if (data.isPublic !== undefined) updateData.isPublic = data.isPublic;
+    updateData.updatedAt = new Date();
 
     try {
       if (Object.keys(updateData).length > 0) {
@@ -165,6 +166,7 @@ export const updateFilter = ownsFilterProcedure
               max: item.max,
               buffer: item.buffer,
               min: item.min,
+              updatedAt: new Date(),
             };
           },
         );


### PR DESCRIPTION
Add updatedAt field to ensure the timestamp is updated whenever a filter is edited.