### PR TITLE
fix(api): add no-store cache to fetch and remove kv expiry

### DIFF
--- a/src/app/api/cron/game-hours/route.ts
+++ b/src/app/api/cron/game-hours/route.ts
@@ -17,13 +17,15 @@ export async function GET(req: NextRequest) {
   const url = `http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=${STEAM_API_KEY}&steamid=${STEAM_ID}&format=json`;
 
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      cache: "no-store",
+    });
     const data = await res.json();
     const gameHours = Math.floor(
       data.response.games.find((game: any) => game.appid === RUST_APP_ID)
         .playtime_forever / 60,
     );
-    await kv.set("gameHours", gameHours, { ex: 60 * 60 * 24 });
+    await kv.set("gameHours", gameHours);
     return NextResponse.json({ gameHours }, { status: 200 });
   } catch (error) {
     return NextResponse.json(


### PR DESCRIPTION
- Added `cache: "no-store"` option to fetch request to ensure fresh data.
- Removed expiry option from kv.set to due to cron not being precise.