### PR TITLE
feat(categories): Implement hierarchical category system with subcategories

### DIFF
--- a/src/actions/filterActions.ts
+++ b/src/actions/filterActions.ts
@@ -28,7 +28,8 @@ export const createFilter = authenticatedProcedure
           description: newFilter.description,
           authorId: ctx.userId,
           imagePath: newFilter.imagePath,
-          categoryId: newFilter.categoryId,
+          categoryId: newFilter.category.categoryId,
+          subCategoryId: newFilter.category.subCategoryId,
           isPublic: newFilter.isPublic,
         })
         .returning();
@@ -116,12 +117,23 @@ export const updateFilter = ownsFilterProcedure
   )
   .handler(async ({ input }) => {
     const { data, filterId, removedItems, addedItems } = input;
-    const updateData: Partial<typeof data> & { updatedAt?: Date } = {};
+    const updateData: Partial<{
+      name: string;
+      description: string | undefined;
+      imagePath: string;
+      categoryId: number | null;
+      subCategoryId: number | null;
+      isPublic: boolean | undefined;
+      updatedAt: Date;
+    }> = {};
     if (data.name) updateData.name = data.name;
     if (data.description !== undefined)
       updateData.description = data.description;
     if (data.imagePath) updateData.imagePath = data.imagePath;
-    if (data.categoryId) updateData.categoryId = data.categoryId;
+    if (data.category) {
+      updateData.categoryId = data.category.categoryId;
+      updateData.subCategoryId = data.category.subCategoryId;
+    }
     if (data.isPublic !== undefined) updateData.isPublic = data.isPublic;
     updateData.updatedAt = new Date();
 

--- a/src/app/(app)/my-filters/components/forms/delete-filter-form.tsx
+++ b/src/app/(app)/my-filters/components/forms/delete-filter-form.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import z from "zod";
+import { z } from "zod";
 
 import { deleteFilter } from "@/actions/filterActions";
 import { useServerActionMutation } from "@/hooks/server-action-hooks";
@@ -37,9 +37,6 @@ export function DeleteFilterForm({ cardId, setOpen }: DeleteFilterFormProps) {
   const mutation = useServerActionMutation(deleteFilter, {
     onSuccess: () => {
       toast.success("Filter deleted successfully");
-      queryClient.invalidateQueries({
-        queryKey: ["categories-with-own-filters"],
-      });
       queryClient.invalidateQueries({ queryKey: ["user-filters-by-category"] });
       queryClient.invalidateQueries({ queryKey: ["user-filters"] });
       setOpen(false);

--- a/src/app/(app)/my-filters/edit/[filterId]/edit-filter-form.tsx
+++ b/src/app/(app)/my-filters/edit/[filterId]/edit-filter-form.tsx
@@ -47,7 +47,10 @@ export function EditFilterForm({ filterId }: { filterId: number }) {
       name: "",
       description: "",
       imagePath: "",
-      categoryId: null,
+      category: {
+        categoryId: null,
+        subCategoryId: null,
+      },
       isPublic: false,
       items: [],
     },
@@ -61,9 +64,6 @@ export function EditFilterForm({ filterId }: { filterId: number }) {
     onSuccess: () => {
       toast.success("Filter updated successfully");
       queryClient.invalidateQueries({ queryKey: ["user-filters-by-category"] });
-      queryClient.invalidateQueries({
-        queryKey: ["categories-with-own-filters"],
-      });
       refetch();
       router.push("/my-filters");
     },
@@ -104,7 +104,10 @@ export function EditFilterForm({ filterId }: { filterId: number }) {
         name: data.name,
         description: data.description ?? "",
         imagePath: data.imagePath,
-        categoryId: data.categoryId,
+        category: {
+          categoryId: data.categoryId,
+          subCategoryId: data.subCategoryId,
+        },
         isPublic: data.isPublic,
         items: initialItemsData,
       });
@@ -240,7 +243,7 @@ export function EditFilterForm({ filterId }: { filterId: number }) {
           />
           <FormField
             control={form.control}
-            name='categoryId'
+            name='category'
             render={({ field }) => (
               <FormItem className='flex flex-col'>
                 <FormLabel>Category</FormLabel>

--- a/src/app/(app)/my-filters/new-filter/new-filter-form.tsx
+++ b/src/app/(app)/my-filters/new-filter/new-filter-form.tsx
@@ -43,7 +43,10 @@ export default function NewFilterForm() {
     defaultValues: {
       name: "",
       imagePath: "",
-      categoryId: null,
+      category: {
+        categoryId: null,
+        subCategoryId: null,
+      },
       description: "",
       items: [],
       isPublic: false,
@@ -62,10 +65,9 @@ export default function NewFilterForm() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({
-        queryKey: ["categories-with-own-filters"],
+        queryKey: ["user-filters-by-category", null],
       });
-      queryClient.invalidateQueries({ queryKey: ["user-filters-by-category"] });
-      queryClient.invalidateQueries({ queryKey: ["user-filters"] });
+      queryClient.invalidateQueries({ queryKey: ["user-category-hierarchy"] });
     },
   });
 
@@ -133,7 +135,7 @@ export default function NewFilterForm() {
           />
           <FormField
             control={form.control}
-            name='categoryId'
+            name='category'
             render={({ field }) => (
               <FormItem className='flex flex-col'>
                 <FormLabel>Category</FormLabel>

--- a/src/app/(app)/my-filters/page.tsx
+++ b/src/app/(app)/my-filters/page.tsx
@@ -7,8 +7,8 @@ import {
 
 import { getBookmarkedFilters } from "@/actions/bookmark-filter";
 import {
-  getCategoriesWithOwnFilters,
   getUserCategories,
+  getUserCategoryHierarchy,
 } from "@/actions/categoryActions";
 import { getUserFiltersByCategory } from "@/lib/queries";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -40,16 +40,16 @@ export default async function MyFiltersPage() {
       },
     }),
     queryClient.prefetchQuery({
-      queryKey: ["categories-with-own-filters"],
+      queryKey: ["user-categories"],
       queryFn: async () => {
-        const [data] = await getCategoriesWithOwnFilters();
+        const [data] = await getUserCategories();
         return data;
       },
     }),
     queryClient.prefetchQuery({
-      queryKey: ["user-categories"],
+      queryKey: ["user-category-hierarchy"],
       queryFn: async () => {
-        const [data] = await getUserCategories();
+        const [data] = await getUserCategoryHierarchy();
         return data;
       },
     }),

--- a/src/components/my-filter-card.tsx
+++ b/src/components/my-filter-card.tsx
@@ -3,7 +3,13 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Edit, EllipsisVertical, ListPlusIcon, Trash2 } from "lucide-react";
+import {
+  CornerDownRight,
+  Edit,
+  EllipsisVertical,
+  ListPlusIcon,
+  Trash2,
+} from "lucide-react";
 
 import { type ConveyorFilter } from "@/types/filter";
 import { useGetUserCategories } from "@/hooks/use-get-user-categories";
@@ -108,16 +114,48 @@ export function MyFilterCard({ filter }: MyFilterCardProps) {
                   <DropdownMenuPortal>
                     <DropdownMenuSubContent>
                       {categories?.map((category) => (
-                        <CategoryDropdownCheckbox
-                          key={category.id}
-                          category={category}
-                          filter={filter}
-                        />
+                        <DropdownMenuGroup key={category.id}>
+                          {/*  Main Categories */}
+                          <CategoryDropdownCheckbox
+                            key={category.id}
+                            category={category}
+                            filter={filter}
+                          />
+
+                          {/* Subcategories Submenu */}
+                          {category.subCategories.length > 0 && (
+                            <DropdownMenuSub defaultOpen>
+                              <DropdownMenuSubTrigger className='pl-8'>
+                                <CornerDownRight className='mr-2 h-4 w-4' />
+                                <span>Subcategories</span>
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent>
+                                {category.subCategories.map((subCategory) => (
+                                  <CategoryDropdownCheckbox
+                                    key={subCategory.id}
+                                    category={subCategory}
+                                    filter={filter}
+                                    isSubCategory
+                                  />
+                                ))}
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+                          )}
+                          {category !== categories[categories.length - 1] && (
+                            <DropdownMenuSeparator />
+                          )}
+                        </DropdownMenuGroup>
                       ))}
                     </DropdownMenuSubContent>
                   </DropdownMenuPortal>
                 </DropdownMenuSub>
-                <ClearFilterCategory filter={filter} />
+
+                {/* Clear Category */}
+                <ClearFilterCategory
+                  filter={filter}
+                  isSubCategory={!!filter.subCategoryId}
+                />
+
                 <DropdownMenuSeparator />
                 <ExportConveyorFilter
                   type='dropdown'

--- a/src/components/my-filters/categories/category-heading-dropdown.tsx
+++ b/src/components/my-filters/categories/category-heading-dropdown.tsx
@@ -17,11 +17,15 @@ import {
 import { DeleteCategoryDialog } from "@/components/my-filters/categories/dialogs/delete-category-dialog";
 import { RenameCategoryDialog } from "@/components/my-filters/categories/dialogs/rename-category-dialog";
 
+interface CategoryHeadingDropdownProps {
+  categoryId: number;
+  isSubCategory?: boolean;
+}
+
 export function CategoryHeadingDropdown({
   categoryId,
-}: {
-  categoryId: number;
-}) {
+  isSubCategory = false,
+}: CategoryHeadingDropdownProps) {
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
@@ -40,7 +44,9 @@ export function CategoryHeadingDropdown({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent>
-            <DropdownMenuLabel>Manage Category</DropdownMenuLabel>
+            <DropdownMenuLabel>
+              Manage {isSubCategory ? "Subcategory" : "Category"}
+            </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DialogTrigger asChild>
               <DropdownMenuItem
@@ -50,11 +56,12 @@ export function CategoryHeadingDropdown({
                 }}
               >
                 <PencilIcon className='mr-2 h-4 w-4' />
-                <span>Rename Category</span>
+                <span>Rename {isSubCategory ? "Subcategory" : "Category"}</span>
               </DropdownMenuItem>
             </DialogTrigger>
             <RenameCategoryDialog
               categoryId={categoryId}
+              isSubCategory={isSubCategory}
               setOpen={setIsRenameDialogOpen}
             />
             <AlertDialogTrigger asChild>
@@ -65,10 +72,13 @@ export function CategoryHeadingDropdown({
                 }}
               >
                 <TrashIcon className='mr-2 h-4 w-4' />
-                <span>Delete Category</span>
+                <span>Delete {isSubCategory ? "Subcategory" : "Category"}</span>
               </DropdownMenuItem>
             </AlertDialogTrigger>
-            <DeleteCategoryDialog categoryId={categoryId} />
+            <DeleteCategoryDialog
+              categoryId={categoryId}
+              isSubCategory={isSubCategory}
+            />
           </DropdownMenuContent>
         </DropdownMenu>
       </Dialog>

--- a/src/components/my-filters/categories/category-heading.tsx
+++ b/src/components/my-filters/categories/category-heading.tsx
@@ -6,21 +6,27 @@ import { Button } from "@/components/ui/button";
 import { CategoryHeadingDropdown } from "@/components/my-filters/categories/category-heading-dropdown";
 import { CreateCategoryDialog } from "@/components/my-filters/categories/dialogs/create-category-dialog";
 
-export function CategoryHeading({
-  title,
-  withAction,
-  categoryId,
-}: {
+interface CategoryHeadingProps {
   title: string;
   withAction?: boolean;
   categoryId?: number;
-}) {
+  isSubCategory?: boolean;
+  canCreateSubcategory?: boolean;
+}
+
+export function CategoryHeading({
+  title,
+  withAction = false,
+  categoryId,
+  isSubCategory = false,
+  canCreateSubcategory = false,
+}: CategoryHeadingProps) {
   return (
     <div className='border-b border-border pb-5 sm:flex sm:items-center sm:justify-between'>
       <h2 className='text-base font-semibold leading-6'>{title}</h2>
       {withAction && (
         <div className='mt-3 sm:ml-4 sm:mt-0'>
-          <CreateCategoryDialog>
+          <CreateCategoryDialog parentId={null}>
             <Button type='button' variant='ghost' size='sm'>
               <PlusIcon className='mr-2 h-4 w-4' />
               Create Category
@@ -29,7 +35,20 @@ export function CategoryHeading({
         </div>
       )}
       {!withAction && categoryId && (
-        <CategoryHeadingDropdown categoryId={categoryId} />
+        <div className='flex items-center gap-2'>
+          {canCreateSubcategory && !isSubCategory && (
+            <CreateCategoryDialog parentId={categoryId}>
+              <Button type='button' variant='ghost' size='sm'>
+                <PlusIcon className='mr-2 h-4 w-4' />
+                Add Subcategory
+              </Button>
+            </CreateCategoryDialog>
+          )}
+          <CategoryHeadingDropdown
+            categoryId={categoryId}
+            isSubCategory={isSubCategory}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/my-filters/categories/clear-filter-category.tsx
+++ b/src/components/my-filters/categories/clear-filter-category.tsx
@@ -9,7 +9,15 @@ import { clearFilterCategory } from "@/actions/categoryActions";
 import { useServerActionMutation } from "@/hooks/server-action-hooks";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
-export function ClearFilterCategory({ filter }: { filter: ConveyorFilter }) {
+interface ClearFilterCategoryProps {
+  filter: ConveyorFilter;
+  isSubCategory?: boolean;
+}
+
+export function ClearFilterCategory({
+  filter,
+  isSubCategory = false,
+}: ClearFilterCategoryProps) {
   const queryClient = useQueryClient();
   const { mutate: clearCategory } = useServerActionMutation(
     clearFilterCategory,
@@ -17,10 +25,10 @@ export function ClearFilterCategory({ filter }: { filter: ConveyorFilter }) {
       onSuccess: () => {
         toast.success("Filter category cleared");
         queryClient.invalidateQueries({
-          queryKey: ["categories-with-own-filters"],
+          queryKey: ["user-filters-by-category", null],
         });
         queryClient.invalidateQueries({
-          queryKey: ["user-filters-by-category", null],
+          queryKey: ["user-category-hierarchy"],
         });
       },
       onError: () => {
@@ -28,18 +36,20 @@ export function ClearFilterCategory({ filter }: { filter: ConveyorFilter }) {
       },
     },
   );
+
   const handleClearCategory = () => {
-    clearCategory({ filterId: filter.id });
+    clearCategory({ filterId: filter.id, isSubCategory });
   };
+  const isDisabled = isSubCategory ? !filter.subCategoryId : !filter.categoryId;
 
   return (
     <DropdownMenuItem
       className='flex items-center'
       onSelect={handleClearCategory}
-      disabled={!filter.categoryId}
+      disabled={isDisabled}
     >
       <ListXIcon className='mr-2 h-4 w-4' />
-      Clear category
+      Clear {isSubCategory ? "subcategory" : "category"}
     </DropdownMenuItem>
   );
 }

--- a/src/components/my-filters/categories/dialogs/create-category-dialog.tsx
+++ b/src/components/my-filters/categories/dialogs/create-category-dialog.tsx
@@ -11,11 +11,15 @@ import {
 } from "@/components/ui/dialog";
 import { CreateCategoryForm } from "@/components/my-filters/categories/forms/create-category-form";
 
+interface CreateCategoryDialogProps {
+  children: React.ReactNode;
+  parentId: number | null;
+}
+
 export function CreateCategoryDialog({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+  parentId,
+}: CreateCategoryDialogProps) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -23,9 +27,11 @@ export function CreateCategoryDialog({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create Category</DialogTitle>
+          <DialogTitle>
+            {parentId ? "Add Subcategory" : "Create Category"}
+          </DialogTitle>
         </DialogHeader>
-        <CreateCategoryForm setOpen={setOpen} />
+        <CreateCategoryForm setOpen={setOpen} parentId={parentId} />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/my-filters/categories/dialogs/delete-category-dialog.tsx
+++ b/src/components/my-filters/categories/dialogs/delete-category-dialog.tsx
@@ -15,23 +15,38 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
-export function DeleteCategoryDialog({ categoryId }: { categoryId: number }) {
+interface DeleteCategoryDialogProps {
+  categoryId: number;
+  isSubCategory?: boolean;
+}
+
+export function DeleteCategoryDialog({
+  categoryId,
+  isSubCategory = false,
+}: DeleteCategoryDialogProps) {
   const queryClient = useQueryClient();
   const { mutate: deleteCategoryMutate } = useServerActionMutation(
     deleteCategory,
     {
       onSuccess: () => {
-        toast.success("Category deleted successfully");
-        queryClient.invalidateQueries({ queryKey: ["user-categories"] });
+        toast.success(
+          isSubCategory
+            ? "Subcategory deleted successfully"
+            : "Category deleted successfully",
+        );
         queryClient.invalidateQueries({
-          queryKey: ["categories-with-own-filters"],
+          queryKey: ["user-filters-by-category", null],
         });
         queryClient.invalidateQueries({
-          queryKey: ["user-filters-by-category"],
+          queryKey: ["user-category-hierarchy"],
         });
       },
       onError: () => {
-        toast.error("Failed to delete category");
+        toast.error(
+          isSubCategory
+            ? "Failed to delete subcategory"
+            : "Failed to delete category",
+        );
       },
     },
   );
@@ -39,17 +54,20 @@ export function DeleteCategoryDialog({ categoryId }: { categoryId: number }) {
   return (
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogTitle>Delete Category</AlertDialogTitle>
+        <AlertDialogTitle>
+          Delete {isSubCategory ? "Subcategory" : "Category"}
+        </AlertDialogTitle>
         <AlertDialogDescription>
-          Are you sure you want to delete this category? This action can&apos;t
-          be undone.
+          Are you sure you want to delete this{" "}
+          {isSubCategory ? "subcategory" : "category"}? All filters in this{" "}
+          {isSubCategory ? "subcategory" : "category"} will be uncategorized.
         </AlertDialogDescription>
       </AlertDialogHeader>
       <AlertDialogFooter>
         <AlertDialogCancel>Cancel</AlertDialogCancel>
         <AlertDialogAction
           onClick={() => {
-            deleteCategoryMutate({ categoryId });
+            deleteCategoryMutate({ categoryId, isSubCategory });
           }}
         >
           Delete

--- a/src/components/my-filters/categories/dialogs/delete-category-dialog.tsx
+++ b/src/components/my-filters/categories/dialogs/delete-category-dialog.tsx
@@ -38,6 +38,9 @@ export function DeleteCategoryDialog({
           queryKey: ["user-filters-by-category", null],
         });
         queryClient.invalidateQueries({
+          queryKey: ["user-categories"],
+        });
+        queryClient.invalidateQueries({
           queryKey: ["user-category-hierarchy"],
         });
       },

--- a/src/components/my-filters/categories/dialogs/rename-category-dialog.tsx
+++ b/src/components/my-filters/categories/dialogs/rename-category-dialog.tsx
@@ -7,19 +7,27 @@ import { RenameCategoryForm } from "@/components/my-filters/categories/forms/ren
 
 export interface RenameCategoryDialogProps {
   categoryId: number;
+  isSubCategory?: boolean;
   setOpen: (open: boolean) => void;
 }
 
 export function RenameCategoryDialog({
   categoryId,
+  isSubCategory = false,
   setOpen,
 }: RenameCategoryDialogProps) {
   return (
     <DialogContent>
       <DialogHeader>
-        <DialogTitle>Rename Category</DialogTitle>
+        <DialogTitle>
+          Rename {isSubCategory ? "Subcategory" : "Category"}
+        </DialogTitle>
       </DialogHeader>
-      <RenameCategoryForm categoryId={categoryId} setOpen={setOpen} />
+      <RenameCategoryForm
+        categoryId={categoryId}
+        isSubCategory={isSubCategory}
+        setOpen={setOpen}
+      />
     </DialogContent>
   );
 }

--- a/src/components/my-filters/categories/forms/create-category-form.tsx
+++ b/src/components/my-filters/categories/forms/create-category-form.tsx
@@ -27,11 +27,15 @@ const formSchema = z.object({
     .max(255, { message: "Category name must be at most 255 characters long" }),
 });
 
+interface CreateCategoryFormProps {
+  setOpen: (open: boolean) => void;
+  parentId: number | null;
+}
+
 export function CreateCategoryForm({
   setOpen,
-}: {
-  setOpen: (open: boolean) => void;
-}) {
+  parentId,
+}: CreateCategoryFormProps) {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -45,11 +49,17 @@ export function CreateCategoryForm({
     createCategoryAction,
     {
       onSuccess: () => {
-        toast.success("Category created successfully");
+        toast.success(
+          parentId
+            ? "Subcategory created successfully"
+            : "Category created successfully",
+        );
         setOpen(false);
-        queryClient.invalidateQueries({ queryKey: ["user-categories"] });
         queryClient.invalidateQueries({
-          queryKey: ["categories-with-own-filters"],
+          queryKey: ["user-categories"],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["user-category-hierarchy"],
         });
       },
       onError: (error) => {
@@ -59,7 +69,7 @@ export function CreateCategoryForm({
   );
 
   function onSubmit(data: z.infer<typeof formSchema>) {
-    createCategory({ name: data.name });
+    createCategory({ name: data.name, parentId });
   }
 
   return (
@@ -81,7 +91,7 @@ export function CreateCategoryForm({
                 <Input placeholder='Clothing' {...field} />
               </FormControl>
               <FormDescription>
-                This is the name of the category.
+                This is the name of the {parentId ? "subcategory" : "category"}.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/src/components/my-filters/categories/forms/rename-category-form.tsx
+++ b/src/components/my-filters/categories/forms/rename-category-form.tsx
@@ -65,6 +65,9 @@ export function RenameCategoryForm({
         queryClient.invalidateQueries({
           queryKey: ["user-category-hierarchy"],
         });
+        queryClient.invalidateQueries({
+          queryKey: ["user-categories"],
+        });
       },
       onError: () => {
         toast.error("Failed to rename category");

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -94,8 +94,10 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & {
+    customIndicator?: React.ReactNode;
+  }
+>(({ className, children, checked, customIndicator, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
@@ -107,7 +109,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   >
     <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className='h-4 w-4' />
+        {customIndicator ?? <Check className='h-4 w-4' />}
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -183,18 +185,18 @@ DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuCheckboxItem,
-  DropdownMenuRadioItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
+  DropdownMenuTrigger,
 };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -40,6 +40,10 @@ export const filters = pgTable(
     categoryId: integer("category_id").references(() => userCategories.id, {
       onDelete: "set null",
     }),
+    subCategoryId: integer("sub_category_id").references(
+      () => subCategories.id,
+      { onDelete: "set null" },
+    ),
     viewCount: integer("view_count").default(0),
     exportCount: integer("export_count").default(0),
     popularityScore: integer("popularity_score").default(0),
@@ -79,6 +83,10 @@ export const filtersRelations = relations(filters, ({ many, one }) => ({
   userCategory: one(userCategories, {
     fields: [filters.categoryId],
     references: [userCategories.id],
+  }),
+  subCategory: one(subCategories, {
+    fields: [filters.subCategoryId],
+    references: [subCategories.id],
   }),
 }));
 
@@ -198,12 +206,35 @@ export const userCategories = pgTable("user_categories", {
   userId: varchar("user_id", { length: 255 }).notNull(),
 });
 
+export const subCategories = pgTable("user_sub_categories", {
+  id: serial("id").primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  userId: varchar("user_id", { length: 255 }).notNull(),
+  parentId: integer("parent_id")
+    .notNull()
+    .references(() => userCategories.id, { onDelete: "cascade" }),
+});
+
 export type UserCategory = typeof userCategories.$inferSelect;
 export type NewUserCategory = typeof userCategories.$inferInsert;
+export type SubCategory = typeof subCategories.$inferSelect;
+export type NewSubCategory = typeof subCategories.$inferInsert;
 
 export const userCategoriesRelations = relations(
   userCategories,
   ({ many }) => ({
+    filters: many(filters),
+    subCategories: many(subCategories),
+  }),
+);
+
+export const subCategoriesRelations = relations(
+  subCategories,
+  ({ one, many }) => ({
+    parent: one(userCategories, {
+      fields: [subCategories.parentId],
+      references: [userCategories.id],
+    }),
     filters: many(filters),
   }),
 );

--- a/src/hooks/use-get-categories-with-items.tsx
+++ b/src/hooks/use-get-categories-with-items.tsx
@@ -1,9 +1,0 @@
-import { getCategoriesWithOwnFilters } from "@/actions/categoryActions";
-import { useServerActionQuery } from "@/hooks/server-action-hooks";
-
-export function useGetCategoriesWithOwnFilters() {
-  return useServerActionQuery(getCategoriesWithOwnFilters, {
-    input: undefined,
-    queryKey: ["categories-with-own-filters"],
-  });
-}

--- a/src/hooks/use-get-user-category-hierarchy.tsx
+++ b/src/hooks/use-get-user-category-hierarchy.tsx
@@ -1,0 +1,9 @@
+import { getUserCategoryHierarchy } from "@/actions/categoryActions";
+import { useServerActionQuery } from "@/hooks/server-action-hooks";
+
+export function useGetUserCategoryHierarchy() {
+  return useServerActionQuery(getUserCategoryHierarchy, {
+    input: undefined,
+    queryKey: ["user-category-hierarchy"],
+  });
+}

--- a/src/schemas/filterFormSchema.ts
+++ b/src/schemas/filterFormSchema.ts
@@ -12,7 +12,10 @@ export const createFilterSchema = z.object({
     .or(z.literal("")),
   authorId: z.string().optional(), // set by the server when creating a new filter
   imagePath: z.string().min(1, { message: "You must select an image" }),
-  categoryId: z.number().nullable().default(null),
+  category: z.object({
+    categoryId: z.number().nullable().default(null),
+    subCategoryId: z.number().nullable().default(null),
+  }),
   isPublic: z.boolean().default(false).optional(),
   items: z
     .array(


### PR DESCRIPTION
# Description
## Overview
This PR introduces a hierarchical category system that allows users to organize their filters using both categories and subcategories. This enhancement provides more granular organization capabilities and improves filter management.

## Changes
### Database & Schema
- Added subcategories table with relations to parent categories
- Updated existing category schema to support hierarchical structure
- Modified filter schema to support subcategory assignments

### Features
- Users can now create, rename, and delete subcategories
- Filters can be assigned to both categories and subcategories, but not belong to both at a time
- Enhanced category dropdown with hierarchical display
- Updated filter forms to support subcategory selection
- Improved category management UI with subcategory support

### Technical Improvements
- Refactored category-related components with inline prop types to use interfaces
- Consolidated category queries into a new hierarchy-aware system
- Fixed Zod import inconsistencies
- Added custom icon support in DropdownMenu component

## Breaking Changes
- Category management APIs have been updated to support the new hierarchical structure
- Removed `useGetCategoriesWithOwnFilters` hook in favor of enhanced `useGetUserCategories`