### PR TITLE
style(ui): add overflow styles for card titles

### DIFF
--- a/src/components/filters/filter-card/filter-card-header.tsx
+++ b/src/components/filters/filter-card/filter-card-header.tsx
@@ -13,7 +13,9 @@ export function FilterCardHeader({
   return (
     <CardHeader className='flex-1'>
       <div className='flex items-center justify-between'>
-        <CardTitle className='text-2xl'>{filter.name}</CardTitle>
+        <CardTitle className='overflow-hidden text-2xl text-ellipsis'>
+          {filter.name}
+        </CardTitle>
         <div className='flex items-center'>
           <ShareButton filterId={filter.id} />
           <BookmarkToggle filterId={filter.id} />

--- a/src/components/my-filter-card.tsx
+++ b/src/components/my-filter-card.tsx
@@ -61,7 +61,7 @@ export function MyFilterCard({
   const { data: categories } = useGetUserCategories();
 
   return (
-    <li className='col-span-1 flex min-w-[300px] rounded-md shadow-xs'>
+    <li className='col-span-1 flex min-w-[300px] overflow-hidden rounded-md shadow-xs'>
       <div className='flex w-16 shrink-0 items-center justify-center rounded-l-md border-2 border-foreground/70 bg-card p-1.5 text-sm font-medium text-card-foreground'>
         <Image
           src={getR2ImageUrl(filter.imagePath + ".webp", "medium")}
@@ -70,16 +70,16 @@ export function MyFilterCard({
           height='64'
         />
       </div>
-      <div className='flex flex-1 items-center justify-between rounded-r-md border-2 border-l-0 border-card-foreground/70'>
-        <div className='flex-1 px-4 py-2 text-sm'>
+      <div className='flex flex-1 items-center justify-between overflow-hidden rounded-r-md border-2 border-l-0 border-card-foreground/70'>
+        <div className='flex-1 overflow-hidden px-4 py-2 text-sm'>
           {isFilterShared ? (
-            <p className='font-medium text-foreground/85 transition-colors hover:text-foreground'>
+            <p className='block overflow-hidden font-medium text-ellipsis text-foreground/85 transition-colors hover:text-foreground'>
               {filter.name}
             </p>
           ) : (
             <Link
               href={`/my-filters/edit/${filter.id}`}
-              className='font-medium text-foreground/85 transition-colors hover:text-foreground'
+              className='block overflow-hidden font-medium text-ellipsis text-foreground/85 transition-colors hover:text-foreground'
             >
               {filter.name}
             </Link>

--- a/src/components/my-filter-card.tsx
+++ b/src/components/my-filter-card.tsx
@@ -73,7 +73,7 @@ export function MyFilterCard({
       <div className='flex flex-1 items-center justify-between overflow-hidden rounded-r-md border-2 border-l-0 border-card-foreground/70'>
         <div className='flex-1 overflow-hidden px-4 py-2 text-sm'>
           {isFilterShared ? (
-            <p className='block overflow-hidden font-medium text-ellipsis text-foreground/85 transition-colors hover:text-foreground'>
+            <p className='overflow-hidden font-medium text-ellipsis text-foreground/85 transition-colors hover:text-foreground'>
               {filter.name}
             </p>
           ) : (

--- a/src/components/my-filters/bookmarked-filter-card.tsx
+++ b/src/components/my-filters/bookmarked-filter-card.tsx
@@ -21,9 +21,11 @@ export function BookmarkedFilterCard({ filter }: BookmarkedFilterCardProps) {
           height='64'
         />
       </div>
-      <div className='flex flex-1 items-center justify-between rounded-r-md border-2 border-l-0 border-card-foreground/70'>
-        <div className='flex-1 px-4 py-2 text-sm'>
-          <p className='font-medium'>{filter.name}</p>
+      <div className='flex flex-1 items-center justify-between overflow-hidden rounded-r-md border-2 border-l-0 border-card-foreground/70'>
+        <div className='flex-1 overflow-hidden px-4 py-2 text-sm'>
+          <p className='overflow-hidden font-medium text-ellipsis'>
+            {filter.name}
+          </p>
           <p className='text-muted-foreground'>{`${filter.filterItems.length} items`}</p>
         </div>
         <div className='space-x-2 pr-2'>


### PR DESCRIPTION
If a user makes the Title of their filter too long (without spaces), it either goes outside the card or it widens the filter card.
Add some classes to prevent widening and use ellipsis
Changes do not affect any titles that have spaces in them (goes to next line)

Added styles to the cards on /filters, your filters, and saved filters

Before:
![image](https://github.com/user-attachments/assets/2fbeb7aa-e112-48bc-bf37-442e363d9135)

After:
![image](https://github.com/user-attachments/assets/e9005902-b9de-4762-b6e9-b381c4cee14f)

Before:
![image](https://github.com/user-attachments/assets/5e56431b-1cde-462f-a82d-5b8f6c843963)

After:
![image](https://github.com/user-attachments/assets/6dbf0602-4ea7-4323-84d5-56772de1d417)
